### PR TITLE
Fix Linux install typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For more, read this [online tutorial](http://shiffman.net/p5/kinect/) or check o
 ####  Linux
 
 Requirements?
-```sudo apt-get libusb-1.0-0 libusb-1.0-0-dev```
+```sudo apt-get install libusb-1.0-0 libusb-1.0-0-dev```
 
 #### Windows.
 


### PR DESCRIPTION
`sudo apt-get *install* lib...`

I mean, Linux users will _probably_ figure it out, but this saves them the 3-second head-scratch.